### PR TITLE
Fix cross-domain AJAX option

### DIFF
--- a/file/assets/js/market.js
+++ b/file/assets/js/market.js
@@ -5,7 +5,7 @@ var doge = document.getElementById("dogecoin");
 
 var liveprice = {
   async: true,
-  scroosDomain: true,
+  crossDomain: true,
   url: "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin%2Clitecoin%2Cethereum%2Cdogecoin&vs_currencies=usd",
 
   method: "GET",


### PR DESCRIPTION
## Summary
- fix typo in `market.js` ajax config for live price updates

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68505ad9313083308e6ac4a3d7dd6762